### PR TITLE
chore(nargo): add name to package

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,4 +1,5 @@
 [package]
+name = "noir-trie-proofs"
 authors = [""]
 compiler_version = "0.1"
 


### PR DESCRIPTION
## Description

Newest nightly version of nargo now requires a name field within the Nargo.toml. This little pr adds a name. 