### PR TITLE
Extend compiler version compatibility

### DIFF
--- a/lib/Nargo.toml
+++ b/lib/Nargo.toml
@@ -2,6 +2,6 @@
 name = "noir_trie_proofs"
 type = "lib"
 authors = [""]
-compiler_version = "0.10.0"
+compiler_version = ">=0.10.0"
 
 [dependencies]


### PR DESCRIPTION
As of [Noir v0.19.0](https://github.com/noir-lang/noir/pull/3336), `compiler_version` is now enforced. 

This PR changes he `compiler_version` supported to >=0.10.0, which eases users that would like to import the library and use if with newer Noir versions.

~~Not very rigorously but depth_8_storage_proof was tested to run successfully on Noir v0.21.0 locally with the change.~~

It was `nargo check`able but not executable. Requires syntax updates on logic that e.g. relies on overflows (which is now forbidden by default). Closing this PR for now.