### PR TITLE
bump: noir v0.24.0 -> v0.32.0 - now using explicit numeric generics

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 0.25.0
+          toolchain: 0.32.0
 
       - name: Run nargo test
         run: nargo test

--- a/lib/Nargo.toml
+++ b/lib/Nargo.toml
@@ -2,6 +2,6 @@
 name = "noir_trie_proofs"
 type = "lib"
 authors = [""]
-compiler_version = ">=0.24.0"
+compiler_version = ">=0.32.0"
 
 [dependencies]

--- a/lib/src/node.nr
+++ b/lib/src/node.nr
@@ -12,7 +12,7 @@ use dep::std::hash::keccak256;
 /// * `path` - RLP-encoded proof path
 /// * `depth` - Depth of proof path
 /// * `cur_depth` - Current depth in the proof path
-pub(crate) fn verify_internal_node<PROOF_LEN>(extracted_hash: &mut [u8; KEY_LENGTH], key_ptr: &mut u64, key_nibbles: [u8; NIBBLE_LENGTH], path: [u8; PROOF_LEN], depth: u64, cur_depth: u64)
+pub(crate) fn verify_internal_node<let PROOF_LEN: u64>(extracted_hash: &mut [u8; KEY_LENGTH], key_ptr: &mut u64, key_nibbles: [u8; NIBBLE_LENGTH], path: [u8; PROOF_LEN], depth: u64, cur_depth: u64)
 {
     let in_range = (cur_depth as u8) < (depth - 1) as u8; // Range indicator
 
@@ -35,7 +35,7 @@ pub(crate) fn verify_internal_node<PROOF_LEN>(extracted_hash: &mut [u8; KEY_LENG
 /// # Arguments
 /// * `node` - RLP-encoded trie node
 /// * `hash` - 32-byte hash value
-pub(crate) fn verify_node_hash<N>(node: [u8; N], hash: [u8; KEY_LENGTH])
+pub(crate) fn verify_node_hash<let N: u64>(node: [u8; N], hash: [u8; KEY_LENGTH])
                            -> bool
 {
     // Extract actual length of node
@@ -57,7 +57,7 @@ pub(crate) fn verify_node_hash<N>(node: [u8; N], hash: [u8; KEY_LENGTH])
 ///
 /// # Arguments
 /// * `key` - Array of bytes representing a key
-pub fn key_as_nibbles<KEY_LEN, NIB_LEN>(key: [u8; KEY_LEN]) -> [u8; NIB_LEN]
+pub fn key_as_nibbles<let KEY_LEN: u64, let NIB_LEN: u64>(key: [u8; KEY_LEN]) -> [u8; NIB_LEN]
 {
     assert(NIB_LEN == 2*KEY_LEN);
     
@@ -80,7 +80,7 @@ pub fn key_as_nibbles<KEY_LEN, NIB_LEN>(key: [u8; KEY_LEN]) -> [u8; NIB_LEN]
 /// # Arguments
 /// * `input`: The first field of a leaf/extension node as a (right-padded) byte array
 /// * `length`: The actual length of the data in `input`
-pub(crate) fn compact_decode<MAX_ENC_LEN, NIB_LEN>(input: [u8; MAX_ENC_LEN], length: u64) -> ([u8; NIB_LEN], u64)
+pub(crate) fn compact_decode<let MAX_ENC_LEN: u64, let NIB_LEN: u64>(input: [u8; MAX_ENC_LEN], length: u64) -> ([u8; NIB_LEN], u64)
 {
 
     assert((2 as u32)*(MAX_ENC_LEN as u32) <= ((NIB_LEN + 2) as u32)); // MAX_ENC_LEN should be NIB_LEN/2 or NIB_LEN/2 + 1. TODO
@@ -126,7 +126,7 @@ pub(crate) fn compact_decode<MAX_ENC_LEN, NIB_LEN>(input: [u8; MAX_ENC_LEN], len
 /// * `key` - Array containing the nibbles to be resolved
 /// * `key_ptr` - Pointer to the nibbles in `key` to be resolved
 /// * `node` - RLP-encoded byte array of branch or extension node
-pub fn resolve_nibble32<N>(
+pub fn resolve_nibble32<let N: u64>(
     key: [u8; NIBBLE_LENGTH],
     mut key_ptr: u64,
     node: [u8; N]) ->
@@ -179,7 +179,7 @@ pub fn resolve_nibble32<N>(
 /// * `key` - Array containing the nibbles to be resolved
 /// * `key_ptr` - Pointer to the nibbles in `key` to be resolved
 // TODO: Generalise to accommodate for variable key lengths.
-pub(crate) fn resolve17<N, NUM_FIELDS>(
+pub(crate) fn resolve17<let N: u64, let NUM_FIELDS: u64>(
     node: [u8; N],
     rlp_list: rlp::RLP_List<NUM_FIELDS>,
     key: [u8; NIBBLE_LENGTH],
@@ -233,7 +233,7 @@ pub(crate) fn resolve17<N, NUM_FIELDS>(
 /// * `rlp_list` - RLP list look-up table for `node`
 /// * `key` - Array containing the nibbles to be resolved
 /// * `key_ptr` - Pointer to the nibbles in `key` to be resolved
-pub(crate) fn resolve2<N, NUM_FIELDS, MAX_VALUE_LEN>(
+pub(crate) fn resolve2<let N: u64, let NUM_FIELDS: u64, let MAX_VALUE_LEN: u64>(
     node: [u8; N],
     rlp_list: rlp::RLP_List<NUM_FIELDS>,
     key: [u8; NIBBLE_LENGTH],

--- a/lib/src/rlp.nr
+++ b/lib/src/rlp.nr
@@ -31,7 +31,7 @@ impl RLP_Header
 
 /// RLP list in the form of a look-up table containing the offsets, lengths
 /// and types of the fields together with the total number of fields.
-struct RLP_List<NUM_FIELDS>
+struct RLP_List<let NUM_FIELDS: u64>
 {
     /// Offsets of the fields
     offset: [u64; NUM_FIELDS],
@@ -43,7 +43,7 @@ struct RLP_List<NUM_FIELDS>
     num_fields: u64
 }
 
-impl<NUM_FIELDS> RLP_List<NUM_FIELDS>
+impl<let NUM_FIELDS: u64> RLP_List<NUM_FIELDS>
 {
     /// RLP table constructor taking offsets, lengths, data types and number of
     /// fields as arguments
@@ -59,7 +59,7 @@ impl<NUM_FIELDS> RLP_List<NUM_FIELDS>
 /// # Arguments
 /// * `arr` - RLP-encoded list
 /// * `lenlen` - Number of bytes containing the length of the payload
-pub fn data_len<N>(arr: [u8; N], lenlen: u64) -> u64 {
+pub fn data_len<let N: u64>(arr: [u8; N], lenlen: u64) -> u64 {
     assert(lenlen <= MAX_LEN_IN_BYTES); // Byte length of length of payload must not exceed MAX_LEN_IN_BYTES
     let mut out = 0;
 
@@ -79,7 +79,7 @@ pub fn data_len<N>(arr: [u8; N], lenlen: u64) -> u64 {
 ///
 /// # Arguments
 /// * `arr` - RLP-encoded byte array
-pub fn decode_len<N>(arr: [u8; N]) -> RLP_Header {
+pub fn decode_len<let N: u64>(arr: [u8; N]) -> RLP_Header {
     let prefix = arr[0];
 
     // Prefix range indicators
@@ -133,7 +133,7 @@ pub fn decode_len<N>(arr: [u8; N]) -> RLP_Header {
 ///
 /// # Arguments
 /// * `input` - RLP-encoded string
-pub fn decode0<N>(input: [u8; N]) -> (u64, u64) {
+pub fn decode0<let N: u64>(input: [u8; N]) -> (u64, u64) {
     let mut RLP_Header {offset, length, data_type} = decode_len(input); // Read RLP header of input
 
     let total_len = length + offset; // Data length including RLP header
@@ -153,7 +153,7 @@ pub fn decode0<N>(input: [u8; N]) -> (u64, u64) {
 /// # Quirks
 /// * For string elements, the offset points to the payload, whereas the offset
 ///   of a list element points to the RLP header of that element.
-pub fn decode1<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
+pub fn decode1<let N: u64, let NUM_FIELDS: u64>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
     let mut num_fields: u64 = 0; // Number of fields
     let mut dec_off = [0; NUM_FIELDS]; // Decoded offsets
     let mut dec_len = [0; NUM_FIELDS]; // Decoded lengths
@@ -196,7 +196,7 @@ pub fn decode1<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
 ///
 /// # Arguments
 /// * `input` - RLP-encoded list
-pub fn decode1_small_lis<N, NUM_FIELDS>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
+pub fn decode1_small_lis<let N: u64, let NUM_FIELDS: u64>(input: [u8; N]) -> RLP_List<NUM_FIELDS> {
     let mut num_fields: u64 = 0; // Number of fields
     let mut dec_off = [0; NUM_FIELDS]; // Decoded offsets
     let mut dec_len = [0; NUM_FIELDS]; // Decoded lengths
@@ -323,7 +323,7 @@ fn rlp_length_check() {
 }
 
 // Function for selecting M elements of an array starting at index n
-pub fn take_dot_drop<T, N, M>(arr: [T; N], n: u64) -> [T; M] // = drop n . take M
+pub fn take_dot_drop<T, let N: u64, let M: u64>(arr: [T; N], n: u64) -> [T; M] // = drop n . take M
 {
     let mut out = [dep::std::unsafe::zeroed(); M];
 

--- a/lib/src/state_proof.nr
+++ b/lib/src/state_proof.nr
@@ -10,7 +10,7 @@ use crate::rlp;
 /// Type alias for storage proofs. Assumes value is left-padded with zeros.
 type StateProof<PROOF_LEN> = TrieProof<20, PROOF_LEN, MAX_ACCOUNT_STATE_LENGTH>;
 
-impl<PROOF_LEN, MAX_VALUE_LEN> TrieProof<20, PROOF_LEN, MAX_VALUE_LEN>
+impl<let PROOF_LEN: u64, let MAX_VALUE_LEN: u64> TrieProof<20, PROOF_LEN, MAX_VALUE_LEN>
 {
     /// Ethereum state proof verifier. Returns true if all constraints are satisfied.
     ///
@@ -41,7 +41,7 @@ impl<PROOF_LEN, MAX_VALUE_LEN> TrieProof<20, PROOF_LEN, MAX_VALUE_LEN>
             verify_internal_node(&mut extracted_hash, &mut key_ptr, key_nibbles, path, depth, i);
         }
 
-        self.verify_state_leaf_node(extracted_hash, key.len(), key_ptr, key_nibbles);
+        self.verify_state_leaf_node(extracted_hash, key.len() as u64, key_ptr, key_nibbles);
         
         true
     }

--- a/lib/src/storage_proof.nr
+++ b/lib/src/storage_proof.nr
@@ -10,7 +10,7 @@ use crate::rlp;
 /// Type alias for storage proofs. Assumes value is left-padded with zeros.
 type StorageProof<PROOF_LEN> = TrieProof<32, PROOF_LEN, MAX_STORAGE_VALUE_LENGTH>;
 
-impl<PROOF_LEN, MAX_VALUE_LEN> TrieProof<32, PROOF_LEN, MAX_VALUE_LEN>
+impl<let PROOF_LEN: u64, let MAX_VALUE_LEN: u64> TrieProof<32, PROOF_LEN, MAX_VALUE_LEN>
 {
     /// Ethereum storage proof verifier. Returns true if all constraints are satisfied.
     ///
@@ -44,7 +44,7 @@ impl<PROOF_LEN, MAX_VALUE_LEN> TrieProof<32, PROOF_LEN, MAX_VALUE_LEN>
             verify_internal_node(&mut extracted_hash, &mut key_ptr, key_nibbles, path, depth, i);
         }
 
-        self.verify_storage_leaf_node(extracted_hash, key.len(), key_ptr, key_nibbles);
+        self.verify_storage_leaf_node(extracted_hash, key.len() as u64, key_ptr, key_nibbles);
         
         true
     }

--- a/lib/src/trie_proof.nr
+++ b/lib/src/trie_proof.nr
@@ -4,7 +4,7 @@
 // - bound the sizes of the nodes embedded in `proof` to allow arbitrary fixed-length keys
 // - bound the key length to allow variable-length keys
 // These would require the ability to declare arrays of length expressed as a comptime u64 variable.
-struct TrieProof<KEY_LEN, PROOF_LEN, MAX_VALUE_LEN>
+struct TrieProof<let KEY_LEN: u64, let PROOF_LEN: u64, let MAX_VALUE_LEN: u64>
 {
     /// Unhashed key to look up along proof path
     key: [u8; KEY_LEN],

--- a/lib/src/utils.nr
+++ b/lib/src/utils.nr
@@ -4,7 +4,7 @@
 /// * `dest` - Destination array
 /// * `src` - Source array
 /// * `offset` - Offset in source array 
-pub(crate) fn memcpy<N, M>(dest: &mut [u8; N], src: [u8; M], offset: u64)
+pub(crate) fn memcpy<let N: u64, let M: u64>(dest: &mut [u8; N], src: [u8; M], offset: u64)
 {
     for i in 0..N
     {
@@ -20,7 +20,7 @@ pub(crate) fn memcpy<N, M>(dest: &mut [u8; N], src: [u8; M], offset: u64)
 /// * `array` - Array to be verified against
 /// * `len` - Number of elements to be verified
 /// * `offset` - Offset in `array`
-pub(crate) fn assert_subarray<N, M>(subarray: [u8; N], array: [u8; M], len: u64, offset: u64)
+pub(crate) fn assert_subarray<let N: u64, let M: u64>(subarray: [u8; N], array: [u8; M], len: u64, offset: u64)
 {
     for i in 0..N
     {
@@ -47,7 +47,7 @@ pub(crate) fn byte_to_nibbles(b: u8) -> (u8, u8)
 ///
 /// # Arguments
 /// * `in_value` - Byte array representing a number in big-endian form.
-pub(crate) fn byte_value<N>(in_value: [u8; N]) -> ([u8; N], u64)
+pub(crate) fn byte_value<let N: u64>(in_value: [u8; N]) -> ([u8; N], u64)
 {
     let mut value_length = 0;
 
@@ -72,7 +72,7 @@ pub(crate) fn byte_value<N>(in_value: [u8; N]) -> ([u8; N], u64)
 ///
 /// # Quirks
 /// The empty slots are set to 0.
-pub(crate) fn left_byte_shift<N>(input: [u8; N], n: u64) -> [u8; N]
+pub(crate) fn left_byte_shift<let N: u64>(input: [u8; N], n: u64) -> [u8; N]
 {
     let mut out = [0; N];
 


### PR DESCRIPTION
Bumps noir version to the latest [`v0.32.0`](https://github.com/noir-lang/noir/releases/tag/v0.32.0) and adds explicit types to numeric generics (breaking change)
aka 
now this lib can be used with the latest noir again.




